### PR TITLE
add atom-over-http support

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -594,6 +594,7 @@ version = "0.1.0"
 dependencies = [
  "atom_syndication 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rss 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -762,7 +762,6 @@ dependencies = [
  "derive_builder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-xml 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -10,6 +10,7 @@ websocket = "0.20.2"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
+reqwest = "0.8.7"
 
 [dependencies.rusqlite]
 version = "0.13.0"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -11,11 +11,8 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 reqwest = "0.8.7"
+rss = "1.5.0"
 
 [dependencies.rusqlite]
 version = "0.13.0"
 features = [ "bundled" ]
-
-[dependencies.rss]
-version = "1.5.0"
-features = [ "from_url" ]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -8,6 +8,7 @@ extern crate rusqlite;
 extern crate chrono;
 extern crate websocket;
 extern crate rss;
+extern crate reqwest;
 
 mod protocol;
 mod requests;

--- a/backend/src/processor.rs
+++ b/backend/src/processor.rs
@@ -1,18 +1,84 @@
 use chrono::prelude::*;
-use rusqlite::Connection;
-use std::io::BufReader;
+use rusqlite::{ Connection, Transaction };
+use std::io::Read;
 use std::fs::File;
 use atom_syndication::Feed;
 use rss::Channel;
 use std::time::Duration;
 use std::thread;
+use std::str::FromStr;
 
-fn update_rss(conn: &mut Connection, feed_id: i64, url: &str) -> Result<(), ::rss::Error> {
-    println!("updating rss: {}", url);
+#[derive(Debug)]
+enum UpdateError {
+    /// Couldn't fetch the file from the network
+    NetworkError(::reqwest::Error),
+    /// The file cannot be parsed (malformed, unrecognized format, etc.)
+    ParseError,
+    /// There was an error writing to the database
+    DatabaseError(::rusqlite::Error),
+}
+
+impl From<::rss::Error> for UpdateError {
+    fn from(_rss_error: ::rss::Error) -> UpdateError {
+        UpdateError::ParseError
+    }
+}
+
+impl From<::atom_syndication::Error> for UpdateError {
+    fn from(_atom_error: ::atom_syndication::Error) -> UpdateError {
+        UpdateError::ParseError
+    }
+}
+
+impl From<::reqwest::Error> for UpdateError {
+    fn from(network_error: ::reqwest::Error) -> UpdateError {
+        UpdateError::NetworkError(network_error)
+    }
+}
+
+impl From<::rusqlite::Error> for UpdateError {
+    fn from(db_error: ::rusqlite::Error) -> UpdateError {
+        UpdateError::DatabaseError(db_error)
+    }
+}
+
+fn fetch_url(url: &str) -> Result<String, UpdateError> {
+    if url.starts_with("file://") {
+        let mut file = File::open(&url[7..]).unwrap();
+        let mut buf = String::new();
+        file.read_to_string(&mut buf).unwrap();
+        return Ok(buf)
+    }
+
+    let body = ::reqwest::get(url)?.text()?;
+    Ok(body)
+}
+
+fn process_atom_feed(tx: &Transaction, feed_id: i64, feed_body: &str) -> Result<String, UpdateError> {
+    let feed = Feed::from_str(feed_body)?;
     let now: DateTime<Utc> = Utc::now();
 
-    let channel = Channel::from_url(&url)?;
-    let tx = conn.transaction().unwrap();
+    for entry in feed.entries() {
+        let updated: DateTime<Utc> = 
+            DateTime::parse_from_rfc3339(entry.updated())
+            .map(|t| t.with_timezone::<Utc>(&Utc))
+            .unwrap_or(now);
+        tx.execute("INSERT OR REPLACE INTO feedEntries VALUES ( ?, ?, ?, ?, ?, ? )", &[
+            &feed_id,
+            &entry.title(),
+            &entry.id(),
+            &updated.timestamp(),
+            &entry.summary(),
+            &entry.content().and_then(|x| x.value())
+        ])?;
+    }
+
+    Ok(feed.title().to_owned())
+}
+
+fn process_rss_feed(tx: &Transaction, feed_id: i64, feed_body: &str) -> Result<String, UpdateError> {
+    let channel = Channel::from_str(feed_body)?;
+    let now: DateTime<Utc> = Utc::now();
 
     for item in channel.items() {
         let pub_date: DateTime<Utc> =
@@ -28,57 +94,36 @@ fn update_rss(conn: &mut Connection, feed_id: i64, url: &str) -> Result<(), ::rs
             &pub_date.timestamp(),
             &item.description().unwrap(),
             &item.content().unwrap(),
-        ]).unwrap();
+        ])?;
     }
 
-    tx.execute("UPDATE feeds SET ( title, lastUpdate ) = ( ?, ? ) WHERE id = ?", &[
-        &channel.title(),
-        &Utc::now().timestamp(),
-        &feed_id,
-    ]).unwrap();
-
-    tx.commit().unwrap();
-
-    Ok(())
+    Ok(channel.title().to_owned())
 }
 
-fn update_feed(conn: &mut Connection, feed_id: i64, url: &str) {
+fn update_feed(conn: &mut Connection, feed_id: i64, url: &str) -> Result<(), UpdateError> {
     println!("updating: {}", url);
-    let now: DateTime<Utc> = Utc::now();
 
-    let feed;
-    if url.starts_with("file://") {
-        let file = File::open(&url[7..]).unwrap();
-        feed = Feed::read_from(BufReader::new(file)).unwrap();
-    }
-    else {
-        unimplemented!();
-    }
+    let body = fetch_url(url)?;
+    let tx = conn.transaction()?;
 
-    let tx = conn.transaction().unwrap();
-
-    for entry in feed.entries() {
-        let updated: DateTime<Utc> = 
-            DateTime::parse_from_rfc3339(entry.updated())
-            .map(|t| t.with_timezone::<Utc>(&Utc))
-            .unwrap_or(now);
-        tx.execute("INSERT OR REPLACE INTO feedEntries VALUES ( ?, ?, ?, ?, ?, ? )", &[
-            &feed_id,
-            &entry.title(),
-            &entry.id(),
-            &updated.timestamp(),
-            &entry.summary(),
-            &entry.content().and_then(|x| x.value())
-        ]).unwrap();
-    }
+    let new_title = match process_atom_feed(&tx, feed_id, &body) {
+        Ok(new_title) => new_title,
+        Err(UpdateError::ParseError) => match process_rss_feed(&tx, feed_id, &body) {
+            Ok(new_title) => new_title,
+            Err(error) => return Err(error)
+        },
+        Err(unknown_error) => return Err(unknown_error),
+    };
 
     tx.execute("UPDATE feeds SET ( title, lastUpdate ) = ( ?, ? ) WHERE id = ?", &[
-        &feed.title(),
+        &new_title,
         &Utc::now().timestamp(),
         &feed_id,
-    ]).unwrap();
+    ])?;
 
-    tx.commit().unwrap();
+    tx.commit()?;
+
+    Ok(())
 }
 
 fn sync() {
@@ -107,9 +152,9 @@ fn sync() {
     for to_update in result {
         let cooldown = 30*60;
         if to_update.last_update + cooldown < now.timestamp() {
-            match update_rss(&mut conn, to_update.id, &to_update.url[..]) {
-                Err(_) => update_feed(&mut conn, to_update.id, &to_update.url[..]),
-                _ => {}
+            match update_feed(&mut conn, to_update.id, &to_update.url) {
+                Ok(()) => println!("feed updated successfully"),
+                Err(error) => println!("error updating feed: {:?}", error)
             }
         }
     }


### PR DESCRIPTION
Now we can pull Atom feeds off the web!

This uses the `reqwest` crate as a high-level wrapper over `hyper`. Only one HTTP request per feed is performed, which means we're not using the `from_url` method from the `rss` crate that featured in #11. There's some error handling for:

* DB errors
* Parse errors (this is lacking in any details whatsoever)
* Network errors